### PR TITLE
Fixed unit test

### DIFF
--- a/Carew/Tests/ProcessorTest.php
+++ b/Carew/Tests/ProcessorTest.php
@@ -14,7 +14,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->finder          = $this->getMock('Symfony\Component\Finder\Finder');
+        $this->finder          = $this->getMock('Symfony\Component\Finder\Finder', [], [], '', false);
         $this->processor       = new Processor($this->eventDispatcher, $this->finder);
     }
 


### PR DESCRIPTION
-   Since symfony v2.2.0, `Finder::addAdapter` uses a fluid interface.
  To mock the `Finder`, one has to either mock the `addAdapter` method
  and return the `Finder` object from it or prevent the constructor
  being called. This commit uses the latter approach.
