### PR TITLE
Added Next plugin link

### DIFF
--- a/doc/pages/cookbook/plugins.md
+++ b/doc/pages/cookbook/plugins.md
@@ -8,6 +8,7 @@ Existing Plugins
 ----------------
 
 * [Sami](https://github.com/carew/plugin-sami#readme): Build api doc from carew
+* [Next](https://github.com/gnugat/carew-next#readme): Functions to get next/previous document
 
 Installation
 ------------


### PR DESCRIPTION
I've created a plugin, it registers 2 new functions: `document_previous` and `document_next`.
I use them in my Carew powered blog to display previous/next button at the bottom of each article (I was adding links like this manually until I got fed up).