### PR TITLE
Prevented decoding of encoded HTML in Toc plugin

### DIFF
--- a/Carew/Event/Listener/Body/Toc.php
+++ b/Carew/Event/Listener/Body/Toc.php
@@ -54,7 +54,10 @@ class Toc implements EventSubscriberInterface
             return sprintf('%s="%s"', $matches['attr'], $urls[$i++]);
         }, $body);
 
-        $document->setBody(html_entity_decode($body, ENT_QUOTES, 'UTF-8'));
+        // Decode only encoded UTF-8 chars
+        $document->setBody(preg_replace_callback("/(&#[0-9]+;)/", function ($found) {
+            return html_entity_decode($found[1], ENT_QUOTES | ENT_XML1, 'UTF-8');
+        }, $body));
     }
 
     public static function getSubscribedEvents()

--- a/Carew/Tests/Event/Listener/Body/TocTest.php
+++ b/Carew/Tests/Event/Listener/Body/TocTest.php
@@ -107,4 +107,34 @@ EOL;
 
         $this->assertSame($body, $document->getBody());
     }
+
+    public function testOnDocumentDoesNotDecodeEncodedHtml()
+    {
+        $document = new Document();
+        $document->setPath('index.html');
+        $body = <<<EOL
+<span>And cyrillic letter: А</span>
+<div>
+    &lt;ul class="{% block ul_class '' %}"&gt;
+        {% for document in documents %}
+            &lt;li class="{% block li_class '' %}"&gt;
+                {% block document_list %}
+                    &lt;a href="{{ render_document_path(document) }}"&gt;
+                        {{ render_document_title(document) }}
+                    &lt;/a&gt;
+                {% endblock %}
+            &lt;/li&gt;
+        {% endfor %}
+    &lt;/ul&gt;
+</div>
+EOL;
+        $document->setBody($body);
+
+        $event = new CarewEvent($document);
+
+        $toc = new Toc();
+        $toc->onDocument($event);
+
+        $this->assertSame($body, $document->getBody());
+    }
 }


### PR DESCRIPTION
There are incorrect displaying of HTML in code blocks. You can see [example ](http://carew.github.io/cookbook/helper.html) in official documentation. This commit created to fix it.